### PR TITLE
When you have original handler, this if clause always cause issue

### DIFF
--- a/src/coins.js
+++ b/src/coins.js
@@ -63,9 +63,8 @@ function coins (opts = {}) {
     for (let handlerName in handlers) {
       let { initialState, initialize } = handlers[handlerName]
       state[handlerName] = initialState || {}
-      if (initialize) {
+      if (initialize)
         initialize(state[handlerName], chainInfo, opts)
-      }
     }
   }
 


### PR DESCRIPTION
I'm trying sample `chain.js` from `readme.md`


I assume `readme.md`'s `initialState` and `modules` vocabularies must be `initialBalance` and `handlers` according to current `src/coins.js` implementation.

Then I wanted to managed to run sample below, but tendermint always crashes.

Then I change this if clause, crash has been halted.

Let me put Pull-req as a report and let's initiate discussion.

```
app.use(coins({
  name: 'testcoin',
  initialState: {
    'judd': 10,
    'matt': 10
  },
  handlers: {
    'test': {
      onInput(input, state) {
        if(isNotValid(input)) {
          throw Error('this input isn\'t valid!')
        }
        state[input.senderAddress] -= input.amount
      },

      onOutput(output, state) {
        state[output.receiverAddress] = (state[output.receiverAddress] || 0) + output.amount
      }
    }
  }
}))
```